### PR TITLE
略語リストにあるときにはピリオドのあとに空白を挟まないようにした

### DIFF
--- a/tests/test_trimmer.py
+++ b/tests/test_trimmer.py
@@ -81,7 +81,7 @@ class TestTrimmer(unittest.TestCase):
     # 人名のピリオドが含まれる場合
     def test_not_break_one_sentence(self):
         original_sentence = "Punkt knows that the periods in Mr.Smith and Johann S.Bach do not mark sentence boundaries."
-        expected_sentence = original_sentence
+        expected_sentence = "Punkt knows that the periods in Mr. Smith and Johann S. Bach do not mark sentence boundaries."
         trimmed_sentence = self.trimmer.trim(original_sentence)
         self.assertEqual(expected_sentence, trimmed_sentence)
 
@@ -123,6 +123,13 @@ class TestTrimmer(unittest.TestCase):
     def test_colon_and_continuing_sentence(self):
         original_sentence = "This obviously has drawbacks: paper is wasted, manual vote counting takes time and is potentially more error-prone than electronic vote counting.As tempting as electronic voting may seem, it is important to realize the potential risks and drawbacks."
         expected_sentence = "This obviously has drawbacks:\npaper is wasted, manual vote counting takes time and is potentially more error-prone than electronic vote counting.\nAs tempting as electronic voting may seem, it is important to realize the potential risks and drawbacks."
+        trimmed_sentence = self.trimmer.trim(original_sentence)
+        self.assertEqual(expected_sentence, trimmed_sentence)
+
+    # 略語を含んで空白無しで文章が連続する場合
+    def test_test_continuing_sentences_without_white_space_contain_abbrev(self):
+        original_sentence = "A clinical study that lacks a 2.2 comparison (i.e., a control) group.I like it. I am e.g. hoge."
+        expected_sentence = "A clinical study that lacks a 2.2 comparison (i.e., a control) group.\nI like it.\nI am e.g. hoge."
         trimmed_sentence = self.trimmer.trim(original_sentence)
         self.assertEqual(expected_sentence, trimmed_sentence)
 

--- a/trimtr/trimmer.py
+++ b/trimtr/trimmer.py
@@ -108,7 +108,6 @@ class Trimmer:
     @classmethod
     def _format_shaped_body(cls, shaped_body: str) -> str:
         formatted_body = cls._format_two_more_lines(shaped_body)
-        # formatted_body = cls._format_white_space_after_period(formatted_body)
         return formatted_body
 
     @classmethod
@@ -182,10 +181,6 @@ class Trimmer:
     # 文末の改行1個と[SB]の改行2個などで改行が3個以上発生する可能性があるのでその場合は2個に抑え込む
     def _format_two_more_lines(body: str) -> str:
         return re.sub(r'((\n|\r\n){3,})', "\n\n", body)
-
-    @staticmethod
-    def _format_white_space_after_period(body: str) -> str:
-        return re.sub(r'\. ', ".", body)
 
     @staticmethod
     def _is_abbreviation(token: str) -> bool:

--- a/trimtr/trimmer.py
+++ b/trimtr/trimmer.py
@@ -72,7 +72,7 @@ class Trimmer:
         flagged_body = cls._create_dot_flag(flagged_body)
 
         # 文章が空白などなしに連続すると文末判定されないので空白を挿入する
-        flagged_body = cls._insert_after_period(flagged_body)
+        flagged_body = cls._insert_white_space_after_period(flagged_body)
         return flagged_body
 
     @classmethod
@@ -108,12 +108,22 @@ class Trimmer:
     @classmethod
     def _format_shaped_body(cls, shaped_body: str) -> str:
         formatted_body = cls._format_two_more_lines(shaped_body)
-        formatted_body = cls._format_white_space_after_period(formatted_body)
+        # formatted_body = cls._format_white_space_after_period(formatted_body)
         return formatted_body
 
-    @staticmethod
-    def _insert_after_period(body: str) -> str:
-        return re.sub(r'(\D)\.(\D)', r'\1. \2', body)
+    @classmethod
+    def _insert_white_space_after_period(cls, body: str) -> str:
+        inserted_body = body
+
+        both_ends_period_list = re.findall(r'(\D)\.(\D)', body)
+
+        for bep in both_ends_period_list:
+            token = bep[0] + '.' + bep[1]
+            if not cls._is_abbreviation(token):
+                inserted_space_token = bep[0] + '.' + bep[1] if bep[1] == ' ' else bep[0] + '. ' + bep[1]
+                inserted_body = inserted_body.replace(token, inserted_space_token)
+
+        return inserted_body
 
     @staticmethod
     def _create_sentence_block_flag(body: str) -> str:
@@ -176,3 +186,8 @@ class Trimmer:
     @staticmethod
     def _format_white_space_after_period(body: str) -> str:
         return re.sub(r'\. ', ".", body)
+
+    @staticmethod
+    def _is_abbreviation(token: str) -> bool:
+        sent_tokenize = SentenceTokenizer.get_instance()
+        return token in sent_tokenize._params.abbrev_types


### PR DESCRIPTION
Issue: #20 

- `\D.\D`にマッチしてかつ略語でないときにピリオドのあとに空白を入れるようにした